### PR TITLE
Add tags to images

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 AllCops:
   Exclude:
     - 'db/schema.rb'
+    - 'db/migrate/*'
     - 'log/**/*'
     - 'tmp/**/*'
     - 'vendor/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -48,4 +48,5 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 
+gem 'acts-as-taggable-on', '~> 7.0'
 gem 'simple_form'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,8 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    acts-as-taggable-on (7.0.0)
+      activerecord (>= 5.0, < 6.2)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     arel (9.0.0)
@@ -228,6 +230,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  acts-as-taggable-on (~> 7.0)
   byebug
   capybara
   jquery-rails

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -4,7 +4,9 @@ class ImagesController < ActionController::Base
   end
 
   def create
-    img = Image.create!(image_params)
+    tag_list = image_params[:tag_list].split(',')
+    link = image_params[:link]
+    img = Image.create!(link: link, tag_list: tag_list)
     redirect_to image_path(img.id)
   end
 
@@ -19,6 +21,6 @@ class ImagesController < ActionController::Base
   private
 
   def image_params
-    params.require(:image).permit(:link)
+    params.require(:image).permit(:link, :tag_list)
   end
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,2 +1,3 @@
 class Image < ActiveRecord::Base
+  acts_as_taggable_on :tags
 end

--- a/app/views/images/index.html.erb
+++ b/app/views/images/index.html.erb
@@ -3,5 +3,8 @@
 <% @images.each do |img|%>
   <div>
     <%= image_tag(img.link,width:'400')  %>
+    <p>Tags: 
+      <%= img.tag_list %>
+    </p>
   </div>
 <% end %>

--- a/app/views/images/new.html.erb
+++ b/app/views/images/new.html.erb
@@ -1,5 +1,6 @@
 <h3>Submit a new image!</h3>
 <%= simple_form_for @image do |f| %>
-    <%= f.input :link, as: :url %>
+    <%= f.input :link, as: :url, label: "URL: " %>
+    <%= f.input :tag_list, placeholder: "i.e. dog, city...", label: "Tags: " %>
     <%= f.button :submit %>
 <% end %>

--- a/app/views/images/show.html.erb
+++ b/app/views/images/show.html.erb
@@ -1,2 +1,5 @@
 <h1>This is your image!</h1>
 <%= image_tag(@image.link, width: '400') %>
+<p>Tags: 
+  <%= @image.tag_list %>
+</p>

--- a/db/migrate/20210114201143_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20210114201143_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
@@ -1,0 +1,37 @@
+# This migration comes from acts_as_taggable_on_engine (originally 1)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class ActsAsTaggableOnMigration < ActiveRecord::Migration[4.2]; end
+else
+  class ActsAsTaggableOnMigration < ActiveRecord::Migration; end
+end
+ActsAsTaggableOnMigration.class_eval do
+  def self.up
+    create_table ActsAsTaggableOn.tags_table do |t|
+      t.string :name
+      t.timestamps
+    end
+
+    create_table ActsAsTaggableOn.taggings_table do |t|
+      t.references :tag, foreign_key: { to_table: ActsAsTaggableOn.tags_table }
+
+      # You should make sure that the column created is
+      # long enough to store the required class names.
+      t.references :taggable, polymorphic: true
+      t.references :tagger, polymorphic: true
+
+      # Limit is created to prevent MySQL error on index
+      # length for MyISAM table type: http://bit.ly/vgW2Ql
+      t.string :context, limit: 128
+
+      t.datetime :created_at
+    end
+
+    add_index ActsAsTaggableOn.taggings_table, :tag_id
+    add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type context], name: 'taggings_taggable_context_idx'
+  end
+
+  def self.down
+    drop_table ActsAsTaggableOn.taggings_table
+    drop_table ActsAsTaggableOn.tags_table
+  end
+end

--- a/db/migrate/20210114201144_add_missing_unique_indices.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20210114201144_add_missing_unique_indices.acts_as_taggable_on_engine.rb
@@ -1,0 +1,26 @@
+# This migration comes from acts_as_taggable_on_engine (originally 2)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingUniqueIndices < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingUniqueIndices < ActiveRecord::Migration; end
+end
+AddMissingUniqueIndices.class_eval do
+  def self.up
+    add_index ActsAsTaggableOn.tags_table, :name, unique: true
+
+    remove_index ActsAsTaggableOn.taggings_table, :tag_id if index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
+    add_index ActsAsTaggableOn.taggings_table,
+              %i[tag_id taggable_id taggable_type context tagger_id tagger_type],
+              unique: true, name: 'taggings_idx'
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.tags_table, :name
+
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_idx'
+
+    add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
+    add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type context], name: 'taggings_taggable_context_idx'
+  end
+end

--- a/db/migrate/20210114201145_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20210114201145_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
@@ -1,0 +1,20 @@
+# This migration comes from acts_as_taggable_on_engine (originally 3)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddTaggingsCounterCacheToTags < ActiveRecord::Migration[4.2]; end
+else
+  class AddTaggingsCounterCacheToTags < ActiveRecord::Migration; end
+end
+AddTaggingsCounterCacheToTags.class_eval do
+  def self.up
+    add_column ActsAsTaggableOn.tags_table, :taggings_count, :integer, default: 0
+
+    ActsAsTaggableOn::Tag.reset_column_information
+    ActsAsTaggableOn::Tag.find_each do |tag|
+      ActsAsTaggableOn::Tag.reset_counters(tag.id, ActsAsTaggableOn.taggings_table)
+    end
+  end
+
+  def self.down
+    remove_column ActsAsTaggableOn.tags_table, :taggings_count
+  end
+end

--- a/db/migrate/20210114201146_add_missing_taggable_index.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20210114201146_add_missing_taggable_index.acts_as_taggable_on_engine.rb
@@ -1,0 +1,15 @@
+# This migration comes from acts_as_taggable_on_engine (originally 4)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingTaggableIndex < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingTaggableIndex < ActiveRecord::Migration; end
+end
+AddMissingTaggableIndex.class_eval do
+  def self.up
+    add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type context], name: 'taggings_taggable_context_idx'
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
+  end
+end

--- a/db/migrate/20210114201147_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20210114201147_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
@@ -1,0 +1,15 @@
+# This migration comes from acts_as_taggable_on_engine (originally 5)
+# This migration is added to circumvent issue #623 and have special characters
+# work properly
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class ChangeCollationForTagNames < ActiveRecord::Migration[4.2]; end
+else
+  class ChangeCollationForTagNames < ActiveRecord::Migration; end
+end
+ChangeCollationForTagNames.class_eval do
+  def up
+    if ActsAsTaggableOn::Utils.using_mysql?
+      execute("ALTER TABLE #{ActsAsTaggableOn.tags_table} MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")
+    end
+  end
+end

--- a/db/migrate/20210114201148_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20210114201148_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
@@ -1,0 +1,23 @@
+# This migration comes from acts_as_taggable_on_engine (originally 6)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingIndexesOnTaggings < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingIndexesOnTaggings < ActiveRecord::Migration; end
+end
+AddMissingIndexesOnTaggings.class_eval do
+  def change
+    add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists? ActsAsTaggableOn.taggings_table, :tag_id
+    add_index ActsAsTaggableOn.taggings_table, :taggable_id unless index_exists? ActsAsTaggableOn.taggings_table, :taggable_id
+    add_index ActsAsTaggableOn.taggings_table, :taggable_type unless index_exists? ActsAsTaggableOn.taggings_table, :taggable_type
+    add_index ActsAsTaggableOn.taggings_table, :tagger_id unless index_exists? ActsAsTaggableOn.taggings_table, :tagger_id
+    add_index ActsAsTaggableOn.taggings_table, :context unless index_exists? ActsAsTaggableOn.taggings_table, :context
+
+    unless index_exists? ActsAsTaggableOn.taggings_table, %i[tagger_id tagger_type]
+      add_index ActsAsTaggableOn.taggings_table, %i[tagger_id tagger_type]
+    end
+
+    unless index_exists? ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type tagger_id context], name: 'taggings_idy'
+      add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type tagger_id context], name: 'taggings_idy'
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,39 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_13_221927) do
+ActiveRecord::Schema.define(version: 2021_01_14_201148) do
 
   create_table "images", force: :cascade do |t|
     t.string "link"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "taggings", force: :cascade do |t|
+    t.integer "tag_id"
+    t.string "taggable_type"
+    t.integer "taggable_id"
+    t.string "tagger_type"
+    t.integer "tagger_id"
+    t.string "context", limit: 128
+    t.datetime "created_at"
+    t.index ["context"], name: "index_taggings_on_context"
+    t.index ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true
+    t.index ["tag_id"], name: "index_taggings_on_tag_id"
+    t.index ["taggable_id", "taggable_type", "context"], name: "taggings_taggable_context_idx"
+    t.index ["taggable_id", "taggable_type", "tagger_id", "context"], name: "taggings_idy"
+    t.index ["taggable_id"], name: "index_taggings_on_taggable_id"
+    t.index ["taggable_type"], name: "index_taggings_on_taggable_type"
+    t.index ["tagger_id", "tagger_type"], name: "index_taggings_on_tagger_id_and_tagger_type"
+    t.index ["tagger_id"], name: "index_taggings_on_tagger_id"
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer "taggings_count", default: 0
+    t.index ["name"], name: "index_tags_on_name", unique: true
   end
 
 end

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -71,6 +71,8 @@ class ImagesControllerTest < ActionDispatch::IntegrationTest
     Image.create(link: 'https://www.appfolio.com/images/html/apm-fb-logo.png')
     Image.create(link: 'https://hips.hearstapps.com/hmg-prod.s3.amazonaws.com/images/dog-puppy-on-garden-royalty-free-image-1586966191.jpg?crop=1.00xw:0.669xh;0,0.190xh&resize=640:*')
     Image.create(link: 'https://cf.ltkcdn.net/dogs/images/orig/235430-2000x1332-australian-shepherd-puppy.jpg')
+    Image.create(link: 'https://cf.ltkcdn.net/dogs/images/orig/235430-2000x1332-australian-shepherd-puppy.jpg',
+                 tag_list: %w[tag1 tag2])
 
     get images_path
     assert_response :success
@@ -80,9 +82,21 @@ class ImagesControllerTest < ActionDispatch::IntegrationTest
       assert_select '[href=?]', '/images/new'
     end
 
-    assert_select 'div img', 3
-    assert_select 'div img' do
-      assert_select '[width=?]', '400'
+    assert_select 'div img', 4
+    assert_select 'div' do
+      assert 'img' do
+        assert_select '[width=?]', '400'
+      end
     end
+
+    expected_tag_text = [
+      'Tags:tag1,tag2',
+      'Tags:',
+      'Tags:',
+      'Tags:'
+    ]
+
+    p_tags_arr = css_select('p')
+    assert_equal p_tags_arr.map { |p_tag| p_tag.text.delete(' ').delete("\n") }, expected_tag_text
   end
 end

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -14,11 +14,30 @@ class ImagesControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test 'create an image' do
+  test 'create an image without tags' do
     assert_difference 'Image.count' do
-      post images_path, params: { image: { link: 'https://www.appfolio.com/images/html/apm-fb-logo.png' } }
+      post images_path, params: {
+        image: {
+          link: 'https://www.appfolio.com/images/html/apm-fb-logo.png',
+          tag_list: ''
+        }
+      }
       assert_redirected_to image_path(Image.last)
     end
+  end
+
+  test 'create an image with tags' do
+    assert_difference 'Image.count' do
+      post images_path, params: {
+        image: {
+          link: 'https://www.appfolio.com/images/html/apm-fb-logo.png',
+          tag_list: 'tag1, tag2'
+        }
+      }
+      assert_redirected_to image_path(Image.last)
+    end
+    img_tags = Image.last.tag_list
+    assert_equal img_tags.length, 2
   end
 
   test 'should show an image' do

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -40,7 +40,7 @@ class ImagesControllerTest < ActionDispatch::IntegrationTest
     assert_equal img_tags.length, 2
   end
 
-  test 'should show an image' do
+  test 'should show an image without tags' do
     created_image = Image.create(link: 'https://www.appfolio.com/images/html/apm-fb-logo.png')
     get image_path(created_image.id)
     assert_response :success
@@ -49,6 +49,22 @@ class ImagesControllerTest < ActionDispatch::IntegrationTest
       assert_select '[src=?]', 'https://www.appfolio.com/images/html/apm-fb-logo.png'
       assert_select '[width=?]', '400'
     end
+    p_tag = css_select('p')
+    assert_equal p_tag.text.strip, 'Tags:'
+  end
+
+  test 'should show an image with tags' do
+    created_image = Image.create(link: 'https://www.appfolio.com/images/html/apm-fb-logo.png',
+                                 tag_list: %w[tag1 tag2])
+    get image_path(created_image.id)
+    assert_response :success
+
+    assert_select 'img' do
+      assert_select '[src=?]', 'https://www.appfolio.com/images/html/apm-fb-logo.png'
+      assert_select '[width=?]', '400'
+    end
+    p_tag = css_select('p')
+    assert_equal p_tag.text.delete(' ').delete("\n"), 'Tags:tag1,tag2'
   end
 
   test 'show images and submission link on index page' do

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -7,7 +7,7 @@ class ImagesControllerTest < ActionDispatch::IntegrationTest
 
     assert_select 'h3', text: 'Submit a new image!'
     assert_select 'form' do
-      assert_select 'div input', 1
+      assert_select 'div input', 2
       assert_select 'input' do
         assert_select '[type=?]', 'submit'
       end

--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class ImageTest < ActiveSupport::TestCase
+  test 'test taggable relationship' do
+    img = Image.create!(link: 'https://cf.ltkcdn.net/dogs/images/orig/235430-2000x1332-australian-shepherd-puppy.jpg',
+                        tag_list: 'tag1, tag2')
+    assert_equal img.tag_list, %w[tag1 tag2]
+
+    img.tag_list.remove('tag1')
+    assert_equal img.tag_list, ['tag2']
+
+    img.tag_list.add('tag10')
+    assert_equal img.tag_list, %w[tag2 tag10]
+
+    img.save!
+    img.reload
+    assert_equal img.tag_list, %w[tag2 tag10]
+  end
+end


### PR DESCRIPTION
- [x] When I add a new image, there is a form field to add tags.
- [x] After I've saved an image with tags, I see those tags displayed with the associated image on the show page
- [x] My application uses the `acts-as-taggable-on` gem to provide the tagging functionality.
- [x] Next to each image on the index page, the tags for that image should be displayed